### PR TITLE
Tweak GitHubUpgrader

### DIFF
--- a/GVFS/GVFS.Common/Git/GitAuthentication.cs
+++ b/GVFS/GVFS.Common/Git/GitAuthentication.cs
@@ -135,7 +135,7 @@ namespace GVFS.Common.Git
             this.isInitialized = true;
             return true;
         }
-
+        
         public bool TryInitializeAndRequireAuth(ITracer tracer, out string errorMessage)
         {
             if (this.isInitialized)

--- a/GVFS/GVFS.Common/GitHubUpgrader.cs
+++ b/GVFS/GVFS.Common/GitHubUpgrader.cs
@@ -1,4 +1,5 @@
-﻿using GVFS.Common.Git;
+using GVFS.Common.FileSystem;
+using GVFS.Common.Git;
 using GVFS.Common.Tracing;
 using System;
 using System.Collections.Generic;
@@ -8,88 +9,88 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Json;
-using System.Security.Cryptography.X509Certificates;
 
 namespace GVFS.Common
 {
-    public class GitHubUpgrader : ProductUpgrader
+    public class GitHubUpgrader : IProductUpgrader
     {
         private const string GitHubReleaseURL = @"https://api.github.com/repos/microsoft/vfsforgit/releases";
         private const string JSONMediaType = @"application/vnd.github.v3+json";
         private const string UserAgent = @"GVFS_Auto_Upgrader";
+        private const string CommonInstallerArgs = "/VERYSILENT /CLOSEAPPLICATIONS /SUPPRESSMSGBOXES /NORESTART";
+        private const string GVFSInstallerArgs = CommonInstallerArgs + " /MOUNTREPOS=false";
+        private const string GitInstallerArgs = CommonInstallerArgs + " /ALLOWDOWNGRADE=1";
         private const string GitAssetId = "Git";
         private const string GVFSAssetId = "GVFS";
         private const string GitInstallerFileNamePrefix = "Git-";
-        private const string PreAndPostInstallerError = "Pre & post installers are not supported in GVFS releases from Github.";
+        private const int RepoMountFailureExitCode = 17;
+        private const string ToolsDirectory = "Tools";
+        private static readonly string UpgraderToolName = GVFSPlatform.Instance.Constants.GVFSUpgraderExecutableName;
+        private static readonly string UpgraderToolConfigFile = UpgraderToolName + ".config";
+        private static readonly string[] UpgraderToolAndLibs =
+            {
+                UpgraderToolName,
+                UpgraderToolConfigFile,
+                "GVFS.Common.dll",
+                "GVFS.Platform.Windows.dll",
+                "Microsoft.Diagnostics.Tracing.EventSource.dll",
+                "netstandard.dll",
+                "System.Net.Http.dll",
+                "Newtonsoft.Json.dll"
+            };
 
+        private Version installedVersion;
         private Release newestRelease;
-        private InstallerCertificateVerifier installerVerifier;
+        private PhysicalFileSystem fileSystem;
+        private ITracer tracer;
 
         public GitHubUpgrader(
             string currentVersion,
-            ITracer tracer, 
-            GitHubUpgraderConfig upgraderConfig, 
-            InstallerCertificateVerifier verifier)
-            : base(currentVersion, tracer)
+            ITracer tracer,
+            GitHubUpgraderConfig upgraderConfig)
+            : this(currentVersion, tracer)
         {
             this.Config = upgraderConfig;
-            this.installerVerifier = verifier;
+        }
+
+        public GitHubUpgrader(string currentVersion, ITracer tracer)
+        {
+            this.installedVersion = new Version(currentVersion);
+            this.fileSystem = new PhysicalFileSystem();
+            this.tracer = tracer;
+
+            string upgradesDirectoryPath = ProductUpgrader.GetUpgradesDirectoryPath();
+            this.fileSystem.CreateDirectory(upgradesDirectoryPath);
         }
 
         public GitHubUpgraderConfig Config { get; private set; }
 
-        public static bool TryCreateGitHubUpgrader(
+        public static GitHubUpgrader Create(
             ITracer tracer,
             out bool isEnabled,
-            out bool isConfigured,
-            out ProductUpgrader upgrader,
-            out string error)
+            out bool isConfigured)
         {
+            GitHubUpgrader upgrader = null;
             LocalGVFSConfig localConfig = new LocalGVFSConfig();
             GitHubUpgraderConfig gitHubUpgraderConfig = new GitHubUpgraderConfig(tracer, localConfig);
 
-            if (gitHubUpgraderConfig.TryLoad(out isEnabled, out isConfigured, out error))
+            if (gitHubUpgraderConfig.TryLoad(out isEnabled, out isConfigured, out string error))
             {
                 upgrader = new GitHubUpgrader(
-                    ProcessHelper.GetCurrentProcessVersion(), 
-                    tracer, 
-                    gitHubUpgraderConfig,
-                    new InstallerCertificateVerifier());
-                return true;
+                    ProcessHelper.GetCurrentProcessVersion(),
+                    tracer);
             }
 
-            upgrader = null;
-            return false;
+            return upgrader;
         }
 
-        public Version QueryLatestVersion()
-        {
-            Version version;
-            string consoleMessage;
-            string error;
-            this.TryGetNewerVersion(out version, out consoleMessage, out error);
-            return version;
-        }
-
-        public void DownloadLatestVersion()
-        {
-            string error;
-            this.TryDownloadNewestVersion(out error);
-        }
-
-        public void InstallLatestVersion()
-        {
-            string error;
-            this.TryDownloadNewestVersion(out error);
-        }
-
-        public override bool Initialize(out string errorMessage)
+        public bool Initialize(out string errorMessage)
         {
             errorMessage = null;
             return true;
         }
 
-        public override bool CanRunUsingCurrentConfig(
+        public bool CanRunUsingCurrentConfig(
             out bool isConfigError, 
             out string consoleMessage,
             out string errorMessage)
@@ -131,7 +132,7 @@ namespace GVFS.Common
             return true;
         }
 
-        public override bool TryGetNewerVersion(
+        public bool TryGetNewerVersion(
             out Version newVersion,
             out string consoleMessage,
             out string errorMessage)
@@ -154,7 +155,7 @@ namespace GVFS.Common
 
                     if (nextRelease.Ring <= this.Config.UpgradeRing &&
                         nextRelease.TryParseVersion(out releaseVersion) &&
-                        releaseVersion > this.InstalledVersion)
+                        releaseVersion > this.installedVersion)
                     {
                         newVersion = releaseVersion;
                         this.newestRelease = nextRelease;
@@ -174,14 +175,14 @@ namespace GVFS.Common
             return false;
         }
 
-        public override bool TryGetGitVersion(out GitVersion gitVersion, out string error)
+        public bool TryGetGitVersion(out GitVersion gitVersion, out string error)
         {
             error = null;
 
             foreach (Asset asset in this.newestRelease.Assets)
             {
                 if (asset.Name.StartsWith(GitInstallerFileNamePrefix) &&
-                    GitVersion.TryParseInstallerName(asset.Name, ProductUpgrader.InstallerExtension, out gitVersion))
+                    GitVersion.TryParseInstallerName(asset.Name, GVFSPlatform.Instance.Constants.InstallerExtension, out gitVersion))
                 {
                     return true;
                 }
@@ -189,23 +190,24 @@ namespace GVFS.Common
 
             error = "Could not find Git version info in newest release";
             gitVersion = null;
+
             return false;
         }
 
-        public override bool TryDownloadNewestVersion(out string errorMessage)
+        public bool TryDownloadNewestVersion(out string errorMessage)
         {
             bool downloadedGit = false;
             bool downloadedGVFS = false;
             foreach (Asset asset in this.newestRelease.Assets)
             {
-                bool targetOSMatch = string.Equals(Path.GetExtension(asset.Name), ProductUpgrader.InstallerExtension, StringComparison.OrdinalIgnoreCase);
+                bool targetOSMatch = string.Equals(Path.GetExtension(asset.Name), GVFSPlatform.Instance.Constants.InstallerExtension, StringComparison.OrdinalIgnoreCase);
                 bool isGitAsset = this.IsGitAsset(asset);
                 bool isGVFSAsset = isGitAsset ? false : this.IsGVFSAsset(asset);
                 if (!targetOSMatch || (!isGVFSAsset && !isGitAsset))
                 {
                     continue;
                 }
-
+ 
                 if (!this.TryDownloadAsset(asset, out errorMessage))
                 {
                     errorMessage = $"Could not download {(isGVFSAsset ? GVFSAssetId : GitAssetId)} installer. {errorMessage}";
@@ -228,7 +230,7 @@ namespace GVFS.Common
             return true;
         }
 
-        public override bool TryRunGitInstaller(out bool installationSucceeded, out string error)
+        public bool TryRunGitInstaller(out bool installationSucceeded, out string error)
         {
             error = null;
             installationSucceeded = false;
@@ -240,19 +242,70 @@ namespace GVFS.Common
             return launched;
         }
 
-        public override bool TryRunGVFSInstaller(out bool installationSucceeded, out string error)
+        public bool TryRunGVFSInstaller(out bool installationSucceeded, out string error)
         {
             error = null;
             installationSucceeded = false;
 
             int exitCode = 0;
             bool launched = this.TryRunInstallerForAsset(GVFSAssetId, out exitCode, out error);
-            installationSucceeded = exitCode == 0 || exitCode == ProductUpgrader.RepoMountFailureExitCode;
+            installationSucceeded = exitCode == 0 || exitCode == RepoMountFailureExitCode;
 
             return launched;
         }
 
-        public override bool TryCleanup(out string error)
+        // TrySetupToolsDirectory -
+        // Copies GVFS Upgrader tool and its dependencies to a temporary location in ProgramData.
+        // Reason why this is needed - When GVFS.Upgrader.exe is run from C:\ProgramFiles\GVFS folder
+        // upgrade installer that is downloaded and run will fail. This is because it cannot overwrite
+        // C:\ProgramFiles\GVFS\GVFS.Upgrader.exe that is running. Moving GVFS.Upgrader.exe along with
+        // its dependencies to a temporary location inside ProgramData and running GVFS.Upgrader.exe 
+        // from this temporary location helps avoid this problem.
+        public virtual bool TrySetupToolsDirectory(out string upgraderToolPath, out string error)
+        {
+            string rootDirectoryPath = ProductUpgrader.GetUpgradesDirectoryPath();
+            string toolsDirectoryPath = Path.Combine(rootDirectoryPath, ToolsDirectory);
+            Exception exception;
+            if (TryCreateDirectory(toolsDirectoryPath, out exception))
+            {
+                string currentPath = ProcessHelper.GetCurrentProcessLocation();
+                error = null;
+                foreach (string name in UpgraderToolAndLibs)
+                {
+                    string toolPath = Path.Combine(currentPath, name);
+                    string destinationPath = Path.Combine(toolsDirectoryPath, name);
+                    try
+                    {
+                        File.Copy(toolPath, destinationPath, overwrite: true);
+                    }
+                    catch (UnauthorizedAccessException e)
+                    {
+                        error = string.Join(
+                            Environment.NewLine, 
+                            "File copy error - " + e.Message, 
+                            $"Make sure you have write permissions to directory {rootDirectoryPath} and run {GVFSConstants.UpgradeVerbMessages.GVFSUpgradeConfirm} again.");
+                        this.TraceException(e, nameof(this.TrySetupToolsDirectory), $"Error copying {toolPath} to {destinationPath}.");
+                        break;
+                    }
+                    catch (IOException e)
+                    {
+                        error = "File copy error - " + e.Message;
+                        this.TraceException(e, nameof(this.TrySetupToolsDirectory), $"Error copying {toolPath} to {destinationPath}.");
+                        break;
+                    }
+                }
+
+                upgraderToolPath = string.IsNullOrEmpty(error) ? Path.Combine(toolsDirectoryPath, UpgraderToolName) : null;
+                return string.IsNullOrEmpty(error);
+            }
+
+            upgraderToolPath = null;
+            error = exception.Message;
+            this.TraceException(exception, nameof(this.TrySetupToolsDirectory), $"Error creating upgrade tools directory {toolsDirectoryPath}.");
+            return false;
+        }
+
+        public bool TryCleanup(out string error)
         {
             error = string.Empty;
             if (this.newestRelease == null)
@@ -279,16 +332,28 @@ namespace GVFS.Common
             return true;
         }
 
+        public void CleanupDownloadDirectory()
+        {
+            try
+            {
+                this.fileSystem.DeleteDirectory(ProductUpgrader.GetAssetDownloadsPath());
+            }
+            catch (Exception ex)
+            {
+                this.TraceException(ex, nameof(this.CleanupDownloadDirectory), $"Could not remove directory: {ProductUpgrader.GetAssetDownloadsPath()}");
+            }
+        }
+
         protected virtual bool TryDeleteDownloadedAsset(Asset asset, out Exception exception)
         {
-            return this.FileSystem.TryDeleteFile(asset.LocalPath, out exception);
+            return this.fileSystem.TryDeleteFile(asset.LocalPath, out exception);
         }
 
         protected virtual bool TryDownloadAsset(Asset asset, out string errorMessage)
         {
             errorMessage = null;
 
-            string downloadPath = GetAssetDownloadsPath();
+            string downloadPath = ProductUpgrader.GetAssetDownloadsPath();
             Exception exception;
             if (!GitHubUpgrader.TryCreateDirectory(downloadPath, out exception))
             {
@@ -348,6 +413,35 @@ namespace GVFS.Common
             return false;
         }
 
+        protected virtual void RunInstaller(string path, string args, out int exitCode, out string error)
+        {
+            ProcessResult processResult = ProcessHelper.Run(path, args);
+
+            exitCode = processResult.ExitCode;
+            error = processResult.Errors;
+        }
+
+        private static bool TryCreateDirectory(string path, out Exception exception)
+        {
+            try
+            {
+                Directory.CreateDirectory(path);
+            }
+            catch (IOException e)
+            {
+                exception = e;
+                return false;
+            }
+            catch (UnauthorizedAccessException e)
+            {
+                exception = e;
+                return false;
+            }
+
+            exception = null;
+            return true;
+        }
+
         private bool TryRunInstallerForAsset(string assetId, out int installerExitCode, out string error)
         {
             error = null;
@@ -356,41 +450,18 @@ namespace GVFS.Common
             bool installerIsRun = false;
             string path;
             string installerArgs;
-            string gitSigner = "CN=Johannes Schindelin, O=Johannes Schindelin";
-            string gvfsSigner = "CN=Microsoft Corporation, O=Microsoft Corporation";
-            string expectedPublisher = assetId == GitAssetId ? gitSigner : assetId == GVFSAssetId ? gvfsSigner : null;
-
             if (this.TryGetLocalInstallerPath(assetId, out path, out installerArgs))
             {
-                FileStream installerHandle = null;
-                bool isValidated = true;
-                if (this.installerVerifier != null)
-                {
-                    isValidated = this.installerVerifier.TryGetValidatedFileStream(expectedPublisher, path, out installerHandle, out error);
-                }
-                
-                if (isValidated)
-                {
-                    string logFilePath = GVFSEnlistment.GetNewLogFileName(GetLogDirectoryPath(), Path.GetFileNameWithoutExtension(path));
-                    string args = installerArgs + " /Log=" + logFilePath;
-                    this.RunInstaller(path, args, out installerExitCode, out error);
+                string logFilePath = GVFSEnlistment.GetNewLogFileName(ProductUpgrader.GetLogDirectoryPath(), Path.GetFileNameWithoutExtension(path));
+                string args = installerArgs + " /Log=" + logFilePath;
+                this.RunInstaller(path, args, out installerExitCode, out error);
 
-                    if (installerExitCode != 0 && string.IsNullOrEmpty(error))
-                    {
-                        error = assetId + " installer failed. Error log: " + logFilePath;
-                    }
-
-                    installerIsRun = true;
-                }
-                else
+                if (installerExitCode != 0 && string.IsNullOrEmpty(error))
                 {
-                    installerIsRun = false;
+                    error = assetId + " installer failed. Error log: " + logFilePath;
                 }
 
-                if (installerHandle != null)
-                {
-                    installerHandle.Close();
-                }
+                installerIsRun = true;
             }
             else
             {
@@ -400,22 +471,30 @@ namespace GVFS.Common
             return installerIsRun;
         }
 
+        private void TraceException(Exception exception, string method, string message)
+        {
+            EventMetadata metadata = new EventMetadata();
+            metadata.Add("Method", method);
+            metadata.Add("Exception", exception.ToString());
+            this.tracer.RelatedError(metadata, message, Keywords.Telemetry);
+        }
+
         private bool TryGetLocalInstallerPath(string assetId, out string path, out string args)
         {
             foreach (Asset asset in this.newestRelease.Assets)
             {
-                if (string.Equals(Path.GetExtension(asset.Name), ProductUpgrader.InstallerExtension, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(Path.GetExtension(asset.Name), GVFSPlatform.Instance.Constants.InstallerExtension, StringComparison.OrdinalIgnoreCase))
                 {
                     path = asset.LocalPath;
                     if (assetId == GitAssetId && this.IsGitAsset(asset))
                     {
-                        args = ProductUpgrader.GitInstallerArgs;
+                        args = GitInstallerArgs;
                         return true;
                     }
 
                     if (assetId == GVFSAssetId && this.IsGVFSAsset(asset))
                     {
-                        args = ProductUpgrader.GVFSInstallerArgs;
+                        args = GVFSInstallerArgs;
                         return true;
                     }
                 }
@@ -449,59 +528,6 @@ namespace GVFS.Common
             return false;
         }
 
-        public class InstallerCertificateVerifier
-        {
-            public bool TryGetValidatedFileStream(
-                string expectedPublisher, 
-                string path, 
-                out FileStream validatedStream, 
-                out string error)
-            {
-                try
-                {
-                    validatedStream = null;
-                    FileStream fileStream = File.OpenRead(path);
-                    X509Certificate signer = X509Certificate.CreateFromSignedFile(path);
-                    X509Certificate2 certificate = new X509Certificate2(signer);
-                    var certificateChain = new X509Chain
-                    {
-                        ChainPolicy =
-                        {
-                            RevocationFlag = X509RevocationFlag.EntireChain,
-                            RevocationMode = X509RevocationMode.Online,
-                            UrlRetrievalTimeout = new TimeSpan(0, 1, 0),
-                            VerificationFlags = X509VerificationFlags.NoFlag
-                        }
-                    };
-
-                    bool chainIsValid = certificateChain.Build(certificate);
-                    if (!chainIsValid)
-                    {
-                        error = $"Verification of {path} failed. Invalid certificate chain.";
-                        fileStream.Close();
-                        return false;
-                    }
-
-                    if (!certificate.SubjectName.Name.StartsWith(expectedPublisher, StringComparison.InvariantCultureIgnoreCase))
-                    {
-                        error = $"Verification of {path} failed. Invalid certificate.";
-                        fileStream.Close();
-                        return false;
-                    }
-
-                    error = null;
-                    validatedStream = fileStream;
-                    return true;
-                }
-                catch (Exception ex)
-                {
-                    error = $"Verification of {path} failed. {ex.ToString()}.";
-                    validatedStream = null;
-                    return false;
-                }
-            }
-        }
-
         public class GitHubUpgraderConfig
         {
             public GitHubUpgraderConfig(ITracer tracer, LocalGVFSConfig localGVFSConfig)
@@ -516,9 +542,9 @@ namespace GVFS.Common
                 // Invalid - User has set an incorrect ring
                 // NoConfig - User has Not set any ring yet
                 // None - User has set a valid "None" ring
-                // (Fast should be greater than Slow, 
+                // (Fast should be greater than Slow,
                 //  Slow should be greater than None, None greater than Invalid.)
-                // This is required for the correct implementation of Ring based 
+                // This is required for the correct implementation of Ring based
                 // upgrade logic.
                 Invalid = 0,
                 NoConfig = None - 1,
@@ -529,7 +555,7 @@ namespace GVFS.Common
 
             public RingType UpgradeRing { get; private set; }
             public LocalGVFSConfig LocalConfig { get; private set; }
-            private ITracer Tracer { get; set; }            
+            private ITracer Tracer { get; set; }
 
             public bool TryLoad(out bool isEnabled, out bool isConfigured, out string error)
             {

--- a/GVFS/GVFS.Common/IProductUpgrader.cs
+++ b/GVFS/GVFS.Common/IProductUpgrader.cs
@@ -1,0 +1,31 @@
+using GVFS.Common.Git;
+using System;
+
+namespace GVFS.Common
+{
+    public interface IProductUpgrader
+    {
+        bool CanRunUsingCurrentConfig(
+            out bool isConfigError,
+            out string consoleMessage,
+            out string errorMessage);
+
+        bool Initialize(out string errorMessage);
+
+        bool TryGetNewerVersion(out Version newVersion, out string consoleMessage, out string errorMessage);
+
+        bool TryGetGitVersion(out GitVersion gitVersion, out string error);
+
+        bool TryDownloadNewestVersion(out string errorMessage);
+
+        bool TryRunGitInstaller(out bool installationSucceeded, out string error);
+
+        bool TryRunGVFSInstaller(out bool installationSucceeded, out string error);
+
+        bool TryCleanup(out string error);
+
+        void CleanupDownloadDirectory();
+
+        bool TrySetupToolsDirectory(out string upgraderToolPath, out string error);
+    }
+}

--- a/GVFS/GVFS.Common/ProductUpgrader.Shared.cs
+++ b/GVFS/GVFS.Common/ProductUpgrader.Shared.cs
@@ -9,10 +9,10 @@ namespace GVFS.Common
         public const string UpgradeDirectoryName = "GVFS.Upgrade";
         public const string LogDirectory = "Logs";
         public const string DownloadDirectory = "Downloads";
+        public const string GVFSInstallerFileNamePrefix = "SetupGVFS";
+        public const string VFSForGitInstallerFileNamePrefix = "VFSForGit";
 
         protected const string RootDirectory = UpgradeDirectoryName;
-        protected const string GVFSInstallerFileNamePrefix = "SetupGVFS";
-        protected const string VFSForGitInstallerFileNamePrefix = "VFSForGit";
 
         public static bool IsLocalUpgradeAvailable(string installerExtension)
         {

--- a/GVFS/GVFS.Common/ProductUpgrader.cs
+++ b/GVFS/GVFS.Common/ProductUpgrader.cs
@@ -1,4 +1,4 @@
-﻿using GVFS.Common.FileSystem;
+using GVFS.Common.FileSystem;
 using GVFS.Common.Git;
 using GVFS.Common.Tracing;
 using System;
@@ -6,50 +6,16 @@ using System.IO;
 
 namespace GVFS.Common
 {
-    public abstract partial class ProductUpgrader
+    public partial class ProductUpgrader
     {
-        protected const string CommonInstallerArgs = "/VERYSILENT /CLOSEAPPLICATIONS /SUPPRESSMSGBOXES /NORESTART";
-        protected const string GVFSInstallerArgs = CommonInstallerArgs + " /MOUNTREPOS=false";
-        protected const string GitInstallerArgs = CommonInstallerArgs + " /ALLOWDOWNGRADE=1";
-        protected const int RepoMountFailureExitCode = 17;
-        protected const string ToolsDirectory = "Tools";
-
-        protected static readonly string GitBinPath = GVFSPlatform.Instance.GitInstallation.GetInstalledGitBinPath();
-        protected static readonly string UpgraderToolName = GVFSPlatform.Instance.Constants.GVFSUpgraderExecutableName;
-        protected static readonly string InstallerExtension = GVFSPlatform.Instance.Constants.InstallerExtension;
-        protected static readonly string UpgraderToolConfigFile = UpgraderToolName + ".config";
-        protected static readonly string[] UpgraderToolAndLibs =
+        public static IProductUpgrader CreateUpgrader(ITracer tracer, out string error)
         {
-            UpgraderToolName,
-            UpgraderToolConfigFile,
-            "GVFS.Common.dll",
-            "GVFS.Platform.Windows.dll",
-            "Microsoft.Diagnostics.Tracing.EventSource.dll",
-            "netstandard.dll",
-            "System.Net.Http.dll",
-            "Newtonsoft.Json.dll"
-        };
-
-        protected ProductUpgrader(string currentVersion, ITracer tracer)
-        {
-            this.InstalledVersion = new Version(currentVersion);
-            this.Tracer = tracer;
-            this.FileSystem = new PhysicalFileSystem();
-
-            string upgradesDirectoryPath = GetUpgradesDirectoryPath();
-            this.FileSystem.CreateDirectory(upgradesDirectoryPath);
-        }
-
-        protected Version InstalledVersion { get; set; }
-        protected PhysicalFileSystem FileSystem { get; set; }
-        protected ITracer Tracer { get; set; }
-
-        public static ProductUpgrader CreateUpgrader(ITracer tracer, out string error)
-        {
-            ProductUpgrader upgrader;
+            IProductUpgrader upgrader;
             bool isEnabled;
             bool isConfigured;
-            if (GitHubUpgrader.TryCreateGitHubUpgrader(tracer, out isEnabled, out isConfigured, out upgrader, out error))
+            error = string.Empty;
+            
+            if ((upgrader = GitHubUpgrader.Create(tracer, out isEnabled, out isConfigured)) != null)
             {
                 return upgrader;
             }
@@ -67,154 +33,6 @@ namespace GVFS.Common
 
             error = GVFSConstants.UpgradeVerbMessages.InvalidRingConsoleAlert + Environment.NewLine + Environment.NewLine + "Error: " + error;
             return null;
-        }
-
-        public static void CleanupDownloadDirectory(ITracer tracer)
-        {
-            try
-            {
-                PhysicalFileSystem fileSystem = new PhysicalFileSystem();
-                fileSystem.DeleteDirectory(GetAssetDownloadsPath());
-            }
-            catch (Exception ex)
-            {
-                if (tracer != null)
-                {
-                    tracer.RelatedError($"Could not cleanup upgrade downloads directory: {GetAssetDownloadsPath()}. {ex.ToString()}");
-                }
-            }
-        }
-
-        public abstract bool Initialize(out string errorMessage);
-
-        public abstract bool CanRunUsingCurrentConfig(out bool isConfigError, out string consoleMessage, out string errorMessage);
-
-        public abstract bool TryGetNewerVersion(out Version newVersion, out string consoleMessage, out string errorMessage);
-
-        public abstract bool TryGetGitVersion(out GitVersion gitVersion, out string error);
-
-        public abstract bool TryDownloadNewestVersion(out string errorMessage);
-
-        public abstract bool TryRunGitInstaller(out bool installationSucceeded, out string error);
-
-        public abstract bool TryRunGVFSInstaller(out bool installationSucceeded, out string error);
-
-        public abstract bool TryCleanup(out string error);
-
-        // TrySetupToolsDirectory -
-        // Copies GVFS Upgrader tool and its dependencies to a temporary location in ProgramData.
-        // Reason why this is needed - When GVFS.Upgrader.exe is run from C:\ProgramFiles\GVFS folder
-        // upgrade installer that is downloaded and run will fail. This is because it cannot overwrite
-        // C:\ProgramFiles\GVFS\GVFS.Upgrader.exe that is running. Moving GVFS.Upgrader.exe along with
-        // its dependencies to a temporary location inside ProgramData and running GVFS.Upgrader.exe 
-        // from this temporary location helps avoid this problem.
-        public virtual bool TrySetupToolsDirectory(out string upgraderToolPath, out string error)
-        {
-            string rootDirectoryPath = ProductUpgrader.GetUpgradesDirectoryPath();
-            string toolsDirectoryPath = Path.Combine(rootDirectoryPath, ToolsDirectory);
-            Exception exception;
-            if (TryCreateDirectory(toolsDirectoryPath, out exception))
-            {
-                string currentPath = ProcessHelper.GetCurrentProcessLocation();
-                error = null;
-                foreach (string name in UpgraderToolAndLibs)
-                {
-                    string toolPath = Path.Combine(currentPath, name);
-                    string destinationPath = Path.Combine(toolsDirectoryPath, name);
-                    try
-                    {
-                        File.Copy(toolPath, destinationPath, overwrite: true);
-                    }
-                    catch (UnauthorizedAccessException e)
-                    {
-                        error = string.Join(
-                            Environment.NewLine,
-                            "File copy error - " + e.Message,
-                            $"Make sure you have write permissions to directory {rootDirectoryPath} and run {GVFSConstants.UpgradeVerbMessages.GVFSUpgradeConfirm} again.");
-                        this.TraceException(e, nameof(this.TrySetupToolsDirectory), $"Error copying {toolPath} to {destinationPath}.");
-                        break;
-                    }
-                    catch (IOException e)
-                    {
-                        error = "File copy error - " + e.Message;
-                        this.TraceException(e, nameof(this.TrySetupToolsDirectory), $"Error copying {toolPath} to {destinationPath}.");
-                        break;
-                    }
-                }
-
-                upgraderToolPath = string.IsNullOrEmpty(error) ? Path.Combine(toolsDirectoryPath, UpgraderToolName) : null;
-                return string.IsNullOrEmpty(error);
-            }
-
-            upgraderToolPath = null;
-            error = exception.Message;
-            this.TraceException(exception, nameof(this.TrySetupToolsDirectory), $"Error creating upgrade tools directory {toolsDirectoryPath}.");
-            return false;
-        }
-
-        protected static string GetTempPath()
-        {
-            return Path.Combine(
-                Paths.GetServiceDataRoot(RootDirectory),
-                "InstallerTemp");
-        }
-
-        protected static bool TryCreateDirectory(string path, out Exception exception)
-        {
-            try
-            {
-                Directory.CreateDirectory(path);
-            }
-            catch (IOException e)
-            {
-                exception = e;
-                return false;
-            }
-            catch (UnauthorizedAccessException e)
-            {
-                exception = e;
-                return false;
-            }
-
-            exception = null;
-            return true;
-        }
-
-        protected void TraceException(Exception exception, string method, string message)
-        {
-            EventMetadata metadata = new EventMetadata();
-            metadata.Add("Method", method);
-            metadata.Add("Exception", exception.ToString());
-            this.Tracer.RelatedError(metadata, message, Keywords.Telemetry);
-        }
-
-        protected virtual void RunInstaller(string path, string args, out int exitCode, out string error)
-        {
-            ProcessResult processResult = ProcessHelper.Run(path, args);
-
-            exitCode = processResult.ExitCode;
-            error = processResult.Errors;
-        }
-
-        protected bool TryDeleteDirectory(string path, out Exception exception)
-        {
-            try
-            {
-                this.FileSystem.DeleteDirectory(path);
-            }
-            catch (IOException e)
-            {
-                exception = e;
-                return false;
-            }
-            catch (UnauthorizedAccessException e)
-            {
-                exception = e;
-                return false;
-            }
-
-            exception = null;
-            return true;
         }
     }
 }

--- a/GVFS/GVFS.Service/ProductUpgradeTimer.cs
+++ b/GVFS/GVFS.Service/ProductUpgradeTimer.cs
@@ -57,7 +57,7 @@ namespace GVFS.Service
         {
             string errorMessage = null;
             InstallerPreRunChecker prerunChecker = new InstallerPreRunChecker(this.tracer, string.Empty);
-            ProductUpgrader productUpgrader = ProductUpgrader.CreateUpgrader(this.tracer, out errorMessage);
+            IProductUpgrader productUpgrader = ProductUpgrader.CreateUpgrader(this.tracer, out errorMessage);
 
             if (productUpgrader != null)
             {
@@ -66,7 +66,7 @@ namespace GVFS.Service
                     return;
                 }
 
-                ProductUpgrader.CleanupDownloadDirectory(this.tracer);
+                productUpgrader.CleanupDownloadDirectory();
             }
 
             if (errorMessage != null)
@@ -75,7 +75,7 @@ namespace GVFS.Service
             }
         }
 
-        private bool TryDownloadUpgrade(ProductUpgrader productUpgrader, out string errorMessage)
+        private bool TryDownloadUpgrade(IProductUpgrader productUpgrader, out string errorMessage)
         {
             using (ITracer activity = this.tracer.StartActivity("Checking for product upgrades.", EventLevel.Informational))
             {
@@ -92,7 +92,7 @@ namespace GVFS.Service
                     // Already up-to-date
                     // Make sure there a no asset installers remaining in the Downloads directory. This can happen if user
                     // upgraded by manually downloading and running asset installers.
-                    ProductUpgrader.CleanupDownloadDirectory(this.tracer);
+                    productUpgrader.CleanupDownloadDirectory();
                     errorMessage = null;
                     return true;
                 }
@@ -110,11 +110,11 @@ namespace GVFS.Service
             }
         }
 
-        private void CleanupDownloadsDirectory(ProductUpgrader productUpgrader)
+        private void CleanupDownloadsDirectory(IProductUpgrader productUpgrader)
         {
             if (productUpgrader != null)
             {
-                ProductUpgrader.CleanupDownloadDirectory(this.tracer);
+                productUpgrader.CleanupDownloadDirectory();
                 return;
             }
 

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Mock/MockProductUpgrader.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Mock/MockProductUpgrader.cs
@@ -16,7 +16,7 @@ namespace GVFS.UnitTests.Windows.Mock.Upgrader
         public MockProductUpgrader(
             string currentVersion,
             ITracer tracer,
-            GitHubUpgraderConfig config) : base(currentVersion, tracer, config, verifier: null)
+            GitHubUpgraderConfig config) : base(currentVersion, tracer, config)
         {
             this.DownloadedFiles = new List<string>();
             this.InstallerArgs = new Dictionary<string, Dictionary<string, string>>();

--- a/GVFS/GVFS.Upgrader/UpgradeOrchestrator.cs
+++ b/GVFS/GVFS.Upgrader/UpgradeOrchestrator.cs
@@ -10,7 +10,7 @@ namespace GVFS.Upgrader
     {
         private const EventLevel DefaultEventLevel = EventLevel.Informational;
 
-        private ProductUpgrader upgrader;
+        private IProductUpgrader upgrader;
         private ITracer tracer;
         private InstallerPreRunChecker preRunChecker;
         private TextWriter output;
@@ -18,7 +18,7 @@ namespace GVFS.Upgrader
         private bool mount;
 
         public UpgradeOrchestrator(
-            ProductUpgrader upgrader,
+            IProductUpgrader upgrader,
             ITracer tracer,
             InstallerPreRunChecker preRunChecker,
             TextReader input,
@@ -135,7 +135,7 @@ namespace GVFS.Upgrader
 
             if (!this.upgrader.CanRunUsingCurrentConfig(out isError, out consoleMessage, out error))
             {
-                ProductUpgrader.CleanupDownloadDirectory(this.tracer);
+                this.upgrader.CleanupDownloadDirectory();
                 this.output.WriteLine(consoleMessage);
 
                 if (isError)

--- a/GVFS/GVFS/CommandLine/UpgradeVerb.cs
+++ b/GVFS/GVFS/CommandLine/UpgradeVerb.cs
@@ -13,12 +13,12 @@ namespace GVFS.CommandLine
     {
         private const string UpgradeVerbName = "upgrade";
         private ITracer tracer;
-        private ProductUpgrader upgrader;
+        private IProductUpgrader upgrader;
         private InstallerPreRunChecker prerunChecker;
         private ProcessLauncher processLauncher;
 
         public UpgradeVerb(
-            ProductUpgrader upgrader,
+            IProductUpgrader upgrader,
             ITracer tracer,
             InstallerPreRunChecker prerunChecker,
             ProcessLauncher processWrapper,
@@ -110,7 +110,7 @@ namespace GVFS.CommandLine
             string consoleMessage;
             if (!this.upgrader.CanRunUsingCurrentConfig(out isError, out consoleMessage, out error))
             {
-                ProductUpgrader.CleanupDownloadDirectory(this.tracer);
+                this.upgrader.CleanupDownloadDirectory();
 
                 if (isError)
                 {
@@ -135,7 +135,7 @@ namespace GVFS.CommandLine
             {
                 // Make sure there a no asset installers remaining in the Downloads directory. This can happen if user
                 // upgraded by manually downloading and running asset installers.
-                ProductUpgrader.CleanupDownloadDirectory(this.tracer);
+                this.upgrader.CleanupDownloadDirectory();
                 this.ReportInfoToConsole(upgradeAvailableMessage);
                 return true;
             }


### PR DESCRIPTION
Add `IProduceUpgrade` interface and update consumers to code against it. I think this makes it clearer what the different components do.

I removed some logic that was outside of this refactor. I think some of the changes should come in separately (maybe once we get this initial PR done)?

Thoughts?